### PR TITLE
Add possibility to pass extra yaml files to explorer launches

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "libs/orthopus_vesc"]
 	path = libs/orthopus_vesc
-	url = ../orthopus_vesc.git
+	url = https://github.com/ORTHOPUS-EXPLORER/orthopus_vesc.git

--- a/explorer_bringup/launch/hardware_base.launch.py
+++ b/explorer_bringup/launch/hardware_base.launch.py
@@ -16,7 +16,7 @@ from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument, TimerAction
 from launch.actions import RegisterEventHandler
 from launch.event_handlers import OnProcessExit
-from launch.conditions import IfCondition
+from launch.conditions import IfCondition, UnlessCondition
 from launch.substitutions import Command, FindExecutable, PathJoinSubstitution, LaunchConfiguration
 from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
@@ -28,7 +28,7 @@ def generate_launch_description():
     poc2 = LaunchConfiguration("use_POC2")
     gui = LaunchConfiguration("gui")
     rviz_delay = LaunchConfiguration("rviz_delay")
-
+    use_custom_controllers = LaunchConfiguration("use_custom_controllers")
     can_port = LaunchConfiguration("can_port")
     host_id = LaunchConfiguration("host_id")
 
@@ -79,6 +79,13 @@ def generate_launch_description():
             "extra_controllers_config",
             default_value=explorer_controller_config,
             description="Path to an additional controller config file to merge/overlay",
+        )
+    )
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "use_custom_controllers",
+            default_value="false",
+            description="Whether to use custom controllers defined in this package or default ros2_controllers ones",
         )
     )
 
@@ -150,6 +157,7 @@ def generate_launch_description():
         executable="spawner",
         arguments=["forward_position_controller", "--controller-manager", "/controller_manager"],
         output="log",
+        condition=UnlessCondition(use_custom_controllers)
     )
 
     trajectory_controller_spawner = Node(
@@ -157,6 +165,7 @@ def generate_launch_description():
         executable="spawner",
         arguments=["joint_trajectory_controller", "--controller-manager", "/controller_manager", "--inactive"],
         output="log",
+        condition=UnlessCondition(use_custom_controllers)
     )
 
     rviz_node = Node(

--- a/explorer_bringup/launch/hardware_base.launch.py
+++ b/explorer_bringup/launch/hardware_base.launch.py
@@ -32,6 +32,10 @@ def generate_launch_description():
     can_port = LaunchConfiguration("can_port")
     host_id = LaunchConfiguration("host_id")
 
+    explorer_controller_config = PathJoinSubstitution(
+        [FindPackageShare("explorer_bringup"), "config", "explorer_controller.yaml"]
+    )
+
     # Declare arguments
     declared_arguments = []
     declared_arguments.append(
@@ -70,6 +74,14 @@ def generate_launch_description():
         )
     )
 
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "extra_controllers_config",
+            default_value=explorer_controller_config,
+            description="Path to an additional controller config file to merge/overlay",
+        )
+    )
+
     # Get URDF via xacro
     robot_description = {
         "robot_description": ParameterValue(Command(
@@ -98,7 +110,8 @@ def generate_launch_description():
             Node(package="controller_manager",
                     executable="ros2_control_node",
                     parameters=[
-                        PathJoinSubstitution([FindPackageShare("explorer_bringup"), "config", "explorer_controller.yaml"]), 
+                        explorer_controller_config,
+                        LaunchConfiguration("extra_controllers_config"), 
                         robot_description
                     ],
                     output="both",

--- a/explorer_bringup/launch/simulation_base.launch.py
+++ b/explorer_bringup/launch/simulation_base.launch.py
@@ -26,7 +26,6 @@ from launch_ros.actions import Node
 from launch_ros.parameter_descriptions import ParameterValue
 from launch_ros.substitutions import FindPackageShare
 
-
 def generate_launch_description():
     # Initialize Arguments
     gui = LaunchConfiguration("gui")
@@ -34,7 +33,12 @@ def generate_launch_description():
     poc2 = LaunchConfiguration("use_POC2")
     rviz_delay = LaunchConfiguration("rviz_delay")
     world_file = LaunchConfiguration("world_file")
-    
+    extra_config_file = LaunchConfiguration("extra_controllers_config")
+
+    explorer_controller_config = PathJoinSubstitution(
+        [FindPackageShare("explorer_bringup"), "config", "explorer_controller.yaml"]
+    )
+
     # Declare arguments
     declared_arguments = []
     declared_arguments.append(
@@ -72,6 +76,14 @@ def generate_launch_description():
         )
     )
 
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "extra_controllers_config",
+            default_value=explorer_controller_config,
+            description="Path to an additional controller config file to merge/overlay",
+        )
+    )
+
     node_robot_state_publisher = Node(
         package="robot_state_publisher",
         executable="robot_state_publisher",
@@ -88,6 +100,7 @@ def generate_launch_description():
                     " ", "simulation:=true",
                     " ", "use_ignition:=true",
                     " ", "use_POC2:=", poc2,
+                    " ", "extra_config:=", extra_config_file
                 ]),
                 value_type=str
             )}, 
@@ -118,21 +131,13 @@ def generate_launch_description():
     robot_controller_spawner = Node(
         package="controller_manager",
         executable="spawner",
-        arguments=["forward_position_controller", "--controller-manager", "/controller_manager"],
+        arguments=["forward_position_controller", "--controller-manager", "/controller_manager",  "--inactive"],
     )
 
     trajectory_controller_spawner = Node(
         package="controller_manager",
         executable="spawner",
         arguments=["joint_trajectory_controller", "--controller-manager", "/controller_manager", "--inactive"],
-    )
-    
-    controllers_control_node = Node(package="controller_manager",
-        executable="ros2_control_node",
-        parameters=[
-            PathJoinSubstitution([FindPackageShare("explorer_bringup"), "config", "explorer_controller.yaml"]),
-        ],
-        output="both",
     )
     
     register_event_handler = []
@@ -144,7 +149,6 @@ def generate_launch_description():
                     joint_state_broadcaster_spawner,
                     robot_controller_spawner,
                     trajectory_controller_spawner,
-                    controllers_control_node,
                 ],
             )
         )

--- a/explorer_bringup/launch/simulation_base.launch.py
+++ b/explorer_bringup/launch/simulation_base.launch.py
@@ -34,6 +34,7 @@ def generate_launch_description():
     rviz_delay = LaunchConfiguration("rviz_delay")
     world_file = LaunchConfiguration("world_file")
     extra_config_file = LaunchConfiguration("extra_controllers_config")
+    use_custom_controllers = LaunchConfiguration("use_custom_controllers")
 
     explorer_controller_config = PathJoinSubstitution(
         [FindPackageShare("explorer_bringup"), "config", "explorer_controller.yaml"]
@@ -81,6 +82,13 @@ def generate_launch_description():
             "extra_controllers_config",
             default_value=explorer_controller_config,
             description="Path to an additional controller config file to merge/overlay",
+        )
+    )
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "use_custom_controllers",
+            default_value="false",
+            description="Use custom controllers config file",
         )
     )
 
@@ -131,13 +139,16 @@ def generate_launch_description():
     robot_controller_spawner = Node(
         package="controller_manager",
         executable="spawner",
-        arguments=["forward_position_controller", "--controller-manager", "/controller_manager",  "--inactive"],
+        arguments=["forward_position_controller", "--controller-manager", "/controller_manager"],
+        condition=UnlessCondition(use_custom_controllers)
     )
+
 
     trajectory_controller_spawner = Node(
         package="controller_manager",
         executable="spawner",
         arguments=["joint_trajectory_controller", "--controller-manager", "/controller_manager", "--inactive"],
+        condition=UnlessCondition(use_custom_controllers)
     )
     
     register_event_handler = []
@@ -148,11 +159,12 @@ def generate_launch_description():
                 on_exit=[
                     joint_state_broadcaster_spawner,
                     robot_controller_spawner,
-                    trajectory_controller_spawner,
+                    trajectory_controller_spawner
                 ],
             )
         )
     )
+
     register_event_handler.append(
         RegisterEventHandler(
             event_handler=OnProcessExit(

--- a/explorer_description/gazebo/explorer.gazebo.xacro
+++ b/explorer_description/gazebo/explorer.gazebo.xacro
@@ -1,18 +1,26 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
 
-  <xacro:macro name="explorer_gazebo" params="use_ignition:=^|true">
+  <xacro:macro name="explorer_gazebo" params="use_ignition:=^|true extra_config:=''">
 
     
     <gazebo>
       <xacro:if value="${use_ignition}">
         <plugin filename="gz_ros2_control-system" name="gz_ros2_control::GazeboSimROS2ControlPlugin">
           <parameters>$(find explorer_bringup)/config/explorer_controller.yaml</parameters>
+          <xacro:property name="extra_config" value="$(arg extra_config)" />
+          <xacro:if value="${extra_config != ''}">
+            <parameters>${extra_config}</parameters>
+      </xacro:if>
         </plugin>
       </xacro:if>
       <xacro:unless value="${use_ignition}">
         <plugin name="gazebo_ros2_control" filename="libgazebo_ros2_control.so">
-    <parameters>$(find explorer_bringup)/config/explorer_controller.yaml</parameters>
+        <parameters>$(find explorer_bringup)/config/explorer_controller.yaml</parameters>
+        <xacro:property name="extra_config" value="$(arg extra_config)" />
+        <xacro:if value="${extra_config != ''}">
+                <parameters>${extra_config}</parameters>
+        </xacro:if>
   </plugin>
       </xacro:unless>
 

--- a/explorer_description/ros2_control/explorer_simulation.ros2_control.xacro
+++ b/explorer_description/ros2_control/explorer_simulation.ros2_control.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <xacro:macro name="explorer_ros2_control" params="name use_ignition:=^|true">
+  <xacro:macro name="explorer_ros2_control" params="name use_ignition:=^|true extra_config:=''">
 
     <xacro:include filename="$(find explorer_description)/urdf/explorer_joints.xacro" />
 
@@ -27,7 +27,7 @@
 
     <!-- Import Gazebo definitions + plugin -->
       <xacro:include filename="$(find explorer_description)/gazebo/explorer.gazebo.xacro" />
-      <xacro:explorer_gazebo use_ignition="$(arg use_ignition)"/>
+      <xacro:explorer_gazebo use_ignition="$(arg use_ignition)" extra_config="$(arg extra_config)"/>
 
   </xacro:macro>
 

--- a/explorer_description/urdf/explorer.urdf.xacro
+++ b/explorer_description/urdf/explorer.urdf.xacro
@@ -49,7 +49,7 @@
       <child link="structure"/>
       <origin xyz="0 0.1555 -0.027" rpy="${pi/2} ${pi} ${pi}"/>
       <axis xyz="0 0 1"/>
-      <limit effort="1000.0" lower="-2.97" upper="2.97" velocity="10"/>
+      <limit effort="1000.0" lower="-2.97" upper="2.97" velocity="25"/>
     </joint>
     <xacro:explorer_POC2_description/>
   </xacro:if>

--- a/explorer_description/urdf/explorer.urdf.xacro
+++ b/explorer_description/urdf/explorer.urdf.xacro
@@ -4,6 +4,7 @@
   <xacro:arg name="simulation" default="false" />
     <!-- if Simulation-->
     <xacro:arg name="use_ignition" default="true" />
+    <xacro:arg name="extra_config" default="" />
     <!-- else -->
     <xacro:arg name="can_port" default="vxcan1" />
     <xacro:arg name="host_id" default="45" />
@@ -94,7 +95,7 @@
   <!-- Import explorer ros2_control description -->
   <xacro:if value="$(arg simulation)">
     <xacro:include filename="$(find explorer_description)/ros2_control/explorer_simulation.ros2_control.xacro" />
-    <xacro:explorer_ros2_control name="explorer" use_ignition="$(arg use_ignition)" />
+    <xacro:explorer_ros2_control name="explorer" use_ignition="$(arg use_ignition)" extra_config="$(arg extra_config)"/>
   </xacro:if>
   <xacro:unless value="$(arg simulation)">
     <xacro:include filename="$(find explorer_description)/ros2_control/explorer_actuators.ros2_control.xacro" />

--- a/explorer_description/urdf/explorer_POC2_description.urdf.xacro
+++ b/explorer_description/urdf/explorer_POC2_description.urdf.xacro
@@ -127,7 +127,7 @@
     <child link="link_1"/>
     <origin xyz="0 0 0.0555" rpy="0 0 0"/>
     <axis xyz="0 0 1"/>
-    <limit effort="1000.0" lower="-2.97" upper="2.97" velocity="10"/>
+    <limit effort="1000.0" lower="-2.97" upper="2.97" velocity="25"/>
   </joint>
 
   <joint name="joint_2" type="revolute">
@@ -135,7 +135,7 @@
     <child link="link_2"/>
     <origin xyz="0 0.0265 0.058952" rpy="${pi/2} ${-pi/2} 0"/>
     <axis xyz="0 0 1"/>
-    <limit effort="1000.0" lower="-2.14" upper="2.14" velocity="10"/>
+    <limit effort="1000.0" lower="-2.14" upper="2.14" velocity="25"/>
   </joint>
 
   <joint name="joint_3" type="revolute">
@@ -143,7 +143,7 @@
     <child link="link_3"/>
     <origin xyz="0.413 0 0" rpy="${pi} 0 0"/>
     <axis xyz="0 0 1"/>
-    <limit effort="1000.0" lower="-2.97" upper="2.97" velocity="10"/>
+    <limit effort="1000.0" lower="-2.97" upper="2.97" velocity="25"/>
   </joint>
 
   <joint name="joint_4" type="revolute">
@@ -151,7 +151,7 @@
     <child link="link_4"/>
     <origin xyz="0.1885 0 -0.008" rpy="${pi/2} ${pi} ${pi/2}"/>
     <axis xyz="0 0 1"/>
-    <limit effort="1000.0" lower="-2.97" upper="2.97" velocity="10"/>
+    <limit effort="1000.0" lower="-2.97" upper="2.97" velocity="25"/>
   </joint>
 
   <joint name="joint_5" type="revolute">
@@ -159,7 +159,7 @@
     <child link="link_5"/>
     <origin xyz="0 0.0285 0.1" rpy="${pi/2} 0 ${pi}"/>
     <axis xyz="0 0 1"/>
-    <limit effort="1000.0" lower="-1.8" upper="1.8" velocity="10"/>
+    <limit effort="1000.0" lower="-1.8" upper="1.8" velocity="25"/>
   </joint>
 
   <!-- <joint name="joint_6" type="revolute">

--- a/explorer_description/urdf/explorer_joints.xacro
+++ b/explorer_description/urdf/explorer_joints.xacro
@@ -48,7 +48,7 @@
           <param name="max">0.5</param>
         </command_interface>
         <state_interface name="position">
-          <param name="initial_value">2.91</param>
+          <param name="initial_value">2.5</param>
         </state_interface>
         <state_interface name="velocity"/>
         <state_interface name="effort"/>

--- a/orthopus_vesc_interface/src/orthopus_vesc_interface.cpp
+++ b/orthopus_vesc_interface/src/orthopus_vesc_interface.cpp
@@ -144,7 +144,7 @@ CallbackReturn VESCInterface::on_init(const HardwareInfo& info)
         _print_buf.emplace_back(printMsg_t{now, s});
       }
       else
-        _print_buf_duration *= 0.0;
+        _print_buf_duration  = _print_buf_duration * 0.0;;
       return;
     }
     RCLCPP_INFO(rclcpp::get_logger("VESCInterface"),  "[%s] <= %s", _name.c_str(), s.c_str());


### PR DESCRIPTION
This PR adds the possibility to add a 2nd yaml file to the controller manager both in simulation and on real hardware. For future work, it will allow all people from the project to just pass their config file for their custom controller to the robot launch, without modifying explore_description.

Their is also a small change in orthopus_vesc, because the operator *= for rclcpp::Duration and double was introduced in iron, and i wanted to compile it with humble. i can remove it, from the pr if needed.

And it also put the orthopus_vesc submodule with a absolute, path, otherwise forks of this repo are complicated